### PR TITLE
aligned carousel buttons

### DIFF
--- a/src/scss/carousel.module.scss
+++ b/src/scss/carousel.module.scss
@@ -156,6 +156,7 @@
 .arrow-buttons {
   display: flex;
   padding-bottom: 20px;
+  justify-content: space-around;
 }
 
 .left-button {


### PR DESCRIPTION
## Related Issue

Closes: #314 

### Describe the changes you've made

added `justify-content: space-around` to the parent div of the buttons, just like it is for mobile view

## Type of change

What sort of change have you made:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Describe how have you verified the changes made

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly whereever it was hard to understand.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Screenshots

 Original           | Updated
 :--------------------: |:--------------------:
 
![image](https://user-images.githubusercontent.com/68962290/114285352-510c2400-9a0b-11eb-8e99-645755e4b6eb.png)
 | 
![image](https://user-images.githubusercontent.com/68962290/114285363-6a14d500-9a0b-11eb-8a80-f3ad9cc476c2.png)
 |
 
